### PR TITLE
Play next song when adding after finished playlist

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -259,8 +259,10 @@ function addToPlaylist(index, from){
     $(vidrow).find("#action i").html("clear");
     $(vidrow).appendTo("#playlist");
 
-    if(playing<0)
+    if(playing<0){
+        playing = playlist.length-2;
         playNext();
+    }
 
     getSuggestions(id);
 }


### PR DESCRIPTION
In the current version; if my playlist has finished playing, and then I add a song, it starts playing from the beginning whereas I would want it to start off with the new song I just added. 

If the above was intended, that's fine. But at least I felt the need for this yesterday.