### PR TITLE
Bug fix for copy share link button

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -103,6 +103,8 @@ function(search, player, playlist, $, dragula, Clipboard) {
         });
 
     var getShareLink = function(element){
+        var playing = player.getPlaying();
+
         base_url = window.location.origin + window.location.pathname;
         ids = playlist.getPlaylistIds();
 

--- a/js/player.js
+++ b/js/player.js
@@ -164,6 +164,9 @@ function($, playlist, ytIframe){
         setPlaying: setPlaying,
         getCurrent: function() {
             return playlist.get(playing);
+        },
+        getPlaying: function(){
+            return playing;            
         }
     }
 });


### PR DESCRIPTION
PR for Issue #27 with the requested changes.

Changed two files _main.js_ and _player.js_.

Share link now gets copied and popup shows up as well.